### PR TITLE
URI is uninitialized if this is the only import

### DIFF
--- a/lib/bible_gateway.rb
+++ b/lib/bible_gateway.rb
@@ -2,6 +2,7 @@
 require 'bible_gateway/version'
 require 'nokogiri'
 require 'typhoeus'
+require 'uri'
 
 class BibleGatewayError < StandardError; end
 


### PR DESCRIPTION
Installed the gem by itself and it couldn't identify the usage of URI.

```
[~/source/ruby_libraries/bible_gateway] irb
irb(main):001:0> require 'bible_gateway'
=> true
irb(main):002:0> b = BibleGateway.new
=> #<BibleGateway:0x007fbf7d554b20 @version=:king_james_version>
irb(main):005:0> b.lookup('John 3')
NameError: uninitialized constant BibleGateway::URI
    from /usr/local/var/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bible_gateway-0.0.6/lib/bible_gateway.rb:58:in `passage_url'
    from /usr/local/var/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bible_gateway-0.0.6/lib/bible_gateway.rb:51:in `lookup'
    from (irb):5
    from /usr/local/var/rbenv/versions/2.0.0-p353/bin/irb:12:in `<main>'
irb(main):006:0> quit
```

I just simply added the require for uri and it's able to find it.  I can try to reproduce it with the tests if you'd prefer.

```
[~/source/ruby_libraries/bible_gateway] irb
irb(main):001:0> require 'bible_gateway'
=> true
irb(main):002:0> b = BibleGateway.new
=> #<BibleGateway:0x007fea4163cdc8 @version=:king_james_version>
irb(main):003:0> b.lookup('John 1:1')
=> {:title=>"John 1:1 (King James Version)", :content=>"<p class=\"chapter-1\"><span class=\"chapternum\">1 </span>In the beginning was the Word, and the Word was with God, and the Word was God.</p>"}
irb(main):004:0> quit
```
