### PR TITLE
use http://classic.biblegateway.com and change version number

### DIFF
--- a/lib/bible_gateway.rb
+++ b/lib/bible_gateway.rb
@@ -6,7 +6,7 @@ require 'uri'
 class BibleGatewayError < StandardError; end
 
 class BibleGateway
-  GATEWAY_URL = "http://www.biblegateway.com"
+  GATEWAY_URL = "http://classic.biblegateway.com"
 
   VERSIONS = {
     :american_standard_version => "ASV",

--- a/lib/bible_gateway/version.rb
+++ b/lib/bible_gateway/version.rb
@@ -1,3 +1,3 @@
 class BibleGateway
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end


### PR DESCRIPTION
This gem is currently broken because Bible Gateway has a new layout. Use the new url to fix the error.